### PR TITLE
Improve error handling for mutex locks and HTTP client builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,29 @@ The library supports multiple API endpoints, allowing fallback from cloud to loc
 - Protocol errors for invalid messages
 - Validation errors for invalid parameters
 
+#### Error Handling Patterns (Updated)
+**Mutex Lock Handling:**
+- All mutex `.lock()` calls use `.expect()` with descriptive error messages
+- Mutex poisoning is treated as a critical error that should panic with context
+- Example: `.lock().expect("Failed to acquire endpoint_health mutex lock: mutex was poisoned")`
+
+**HTTP Client Builder Errors:**
+- Client builder errors are properly handled with pattern matching
+- No `.unwrap()` calls on `reqwest::Client::builder().build()`
+- Errors are propagated using `Result` types or handled with fallback logic
+
+**Testing Error Conditions:**
+- Tests verify that mutex operations don't panic under normal conditions
+- Specific test for mutex poisoning behavior with `#[should_panic]`
+- Tests ensure error handling code paths work correctly
+
+**Guidelines for Contributors:**
+1. Never use `.unwrap()` in production code paths
+2. Use `.expect()` with descriptive messages for unrecoverable errors
+3. Prefer `?` operator for error propagation in functions returning Result
+4. Add tests for both success and error conditions
+5. Document panic conditions in function documentation
+
 ## Future Improvements
 
 1. **Performance**: Implement connection pooling for HTTP clients


### PR DESCRIPTION
## Summary
- Replace all `.unwrap()` calls on mutex locks with `.expect()` including descriptive error messages
- Handle `reqwest::Client::builder().build()` errors with pattern matching instead of `.unwrap()`
- Add comprehensive tests for mutex error handling and poisoning behavior
- Document error handling patterns and guidelines in `CLAUDE.md`

## Changes

### Error Handling Improvements
- Updated all mutex `.lock().unwrap()` calls to `.lock().expect("Failed to acquire endpoint_health mutex lock: mutex was poisoned")` to provide clearer panic messages on poisoning
- Replaced `.unwrap()` on `reqwest::Client::builder().build()` with proper `match` to propagate errors instead of panicking

### Testing
- Added tests to verify that mutex locking does not panic under normal conditions
- Added a test to confirm panic occurs with the expected message when mutex is poisoned
- Added tests to ensure error handling code paths for endpoint health tracking and failover strategies do not panic

### Documentation
- Expanded `CLAUDE.md` with detailed error handling patterns:
  - Mutex lock handling with `.expect()` and panic on poisoning
  - HTTP client builder error handling with pattern matching
  - Testing guidelines for error conditions
  - Contributor guidelines to avoid `.unwrap()` in production and prefer `?` or `.expect()` with messages

## Test plan
- Run all new and existing tests to ensure no panics occur except expected mutex poisoning test
- Verify that failover strategies and endpoint health tracking work correctly without panics
- Confirm error messages on mutex poisoning are descriptive and consistent

This PR enhances the robustness and maintainability of the codebase by improving error handling and providing clear guidelines for contributors.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/76d24f2b-9fc8-4dbe-9fea-424aa2888361